### PR TITLE
feat: add SBOM generation and vulnerability scanning

### DIFF
--- a/.github/workflows/buildx-on-pr.yml
+++ b/.github/workflows/buildx-on-pr.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Scan image for vulnerabilities
         id: scan
-        uses: anchore/scan-action@v6
+        uses: anchore/scan-action@v7
         with:
           image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:testing-${{ github.event.pull_request.number }}
           fail-build: true

--- a/.github/workflows/buildx-on-pr.yml
+++ b/.github/workflows/buildx-on-pr.yml
@@ -46,6 +46,29 @@ jobs:
         run: |
           docker run --rm ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:testing-${{ github.event.pull_request.number }} uname
 
+      - name: Generate SBOM
+        uses: anchore/sbom-action@v0
+        with:
+          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:testing-${{ github.event.pull_request.number }}
+          format: spdx-json
+          upload-artifact: true
+          upload-release-assets: false
+
+      - name: Scan image for vulnerabilities
+        id: scan
+        uses: anchore/scan-action@v6
+        with:
+          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:testing-${{ github.event.pull_request.number }}
+          fail-build: true
+          severity-cutoff: high
+          output-format: sarif
+
+      - name: Upload scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: ${{ steps.scan.outputs.sarif }}
+
       - name: Build and Push
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:

--- a/.github/workflows/buildx-on-pr.yml
+++ b/.github/workflows/buildx-on-pr.yml
@@ -68,7 +68,7 @@ jobs:
           output-format: sarif
 
       - name: Upload scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         if: always()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}

--- a/.github/workflows/buildx-on-pr.yml
+++ b/.github/workflows/buildx-on-pr.yml
@@ -64,7 +64,7 @@ jobs:
         with:
           image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:testing-${{ github.event.pull_request.number }}
           fail-build: true
-          severity-cutoff: high
+          severity-cutoff: critical
           output-format: sarif
 
       - name: Upload scan results to GitHub Security tab

--- a/.github/workflows/buildx-on-pr.yml
+++ b/.github/workflows/buildx-on-pr.yml
@@ -11,6 +11,10 @@ env:
 jobs:
   buildx-on-pr:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      security-events: write
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -56,7 +60,7 @@ jobs:
 
       - name: Scan image for vulnerabilities
         id: scan
-        uses: anchore/scan-action@v7
+        uses: anchore/scan-action@v6
         with:
           image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:testing-${{ github.event.pull_request.number }}
           fail-build: true

--- a/.github/workflows/buildx.yml
+++ b/.github/workflows/buildx.yml
@@ -79,8 +79,29 @@ jobs:
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.VER_MINOR }}
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.VER_MAJOR }}
           platforms: ${{ env.PLATFORMS }}
-          provenance: false
+          provenance: mode=max
           push: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
           outputs: type=image,name=target,annotation-index.org.opencontainers.image.description=NetOps Toolkit - Kubernetes Debugging Container
+
+      - name: Generate SBOM
+        uses: anchore/sbom-action@v0
+        with:
+          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.VER_FULL }}
+          format: spdx-json
+          output-file: sbom.spdx.json
+          upload-artifact: true
+
+      - name: Scan image for vulnerabilities
+        id: scan
+        uses: anchore/scan-action@v6
+        with:
+          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.VER_FULL }}
+          output-format: sarif
+          fail-build: false
+
+      - name: Upload scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: ${{ steps.scan.outputs.sarif }}

--- a/.github/workflows/buildx.yml
+++ b/.github/workflows/buildx.yml
@@ -14,6 +14,10 @@ env:
 jobs:
   buildx:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      security-events: write
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7


### PR DESCRIPTION
- buildx.yml: provenance mode=max, generate SBOM via anchore/sbom-action, scan with anchore/scan-action (report-only), upload SARIF to Security tab
- buildx-on-pr.yml: generate SBOM artifact per PR, scan with fail-build=true on HIGH+ CVEs, upload SARIF to Security tab with if: always()